### PR TITLE
Fix github gist issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -852,10 +852,23 @@
         a {
             color: #667eea;
             text-decoration: none;
+            /* Prevent long links from overflowing containers */
+            word-break: break-word;
+            overflow-wrap: anywhere;
         }
 
         a:hover {
             text-decoration: underline;
+        }
+
+        /* Do not underline sidebar navigation links on hover/click */
+        .sidebar .nav-section a,
+        .sidebar .nav-section a:hover,
+        .sidebar .nav-section a:focus,
+        .sidebar .nav-section a:active {
+            text-decoration: none;
+            -webkit-tap-highlight-color: transparent;
+            outline: none;
         }
 
         .highlight {


### PR DESCRIPTION
Remove underline/outline from sidebar navigation links and add word-wrapping to prevent long links from overflowing.

---
<a href="https://cursor.com/background-agent?bcId=bc-76a26a58-b7ef-47b7-bc00-d4353f255d4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-76a26a58-b7ef-47b7-bc00-d4353f255d4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

